### PR TITLE
Move unused procIssues.ipynb to old_programs

### DIFF
--- a/notebooks/old_notebooks/procIssues.ipynb
+++ b/notebooks/old_notebooks/procIssues.ipynb
@@ -45281,7 +45281,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -45295,7 +45295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
ELT2 files aren't too bad, but this will set up the old_notebooks folders so that improving and adding new programs is easier.